### PR TITLE
FEAT: allow scandic letters in email

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,4 @@
-import maskFunction, { defaultMaskOptions  } from '.'
+import maskFunction, { defaultMaskOptions } from '.'
 import shopifyOrderExample from './__mock__/shopify_order.json'
 
 const testObject = {
@@ -31,6 +31,12 @@ const testObject = {
     },
   },
 }
+
+const multilineTestString = `
+https://www.rfc-editor.org/rfc/rfc6531 allows international characters
+in email, for example ääöö@åå.com, and we might want to find them also.
+In addition, we might not want to match all string containting @-sign,
+like foo@bar since this is not an email-address. `
 
 describe('Mask sensitive data', () => {
   describe('Object', () => {
@@ -123,6 +129,20 @@ describe('Mask sensitive data', () => {
           visibleCharsFromStart: 0,
         })
       ).toEqual('***********4567')
+    })
+
+    it('should mask sensitive information from multiline string', () => {
+      expect(
+        maskFunction(multilineTestString, {
+          ...defaultMaskOptions,
+          visibleCharsFromStart: 0,
+          visibleCharsFromEnd: 0,
+        })
+      ).toEqual(`
+https://******************/rfc/rfc6531 allows international characters
+in email, for example ***********, and we might want to find them also.
+In addition, we might not want to match all string containting @-sign,
+like foo@bar since this is not an email-address. `)
     })
   })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ const defaultTextMaskOptions = {
 
 export const defaultMaskOptions = {
   bankCardNumberPattern: /([\d]{4}\W){3}[\d]{4}/g,
-  emailPattern: /[\w+\.+\-]+@+[\w+\.+\-]+[\.\w]{2,}/g,
+  emailPattern: /[\w.öäå-]+@[\w.öäå-]+\.[a-z]{2,}/gim,
   jwtPattern: /[\w-]*\.[\w-]*\.[\w-]*/g,
   phoneNumberPattern:
     /[\+]?[\d]{1,3}?[-\s\.]?[(]?[\d]{1,3}[)]?[-\s\.]?([\d-\s\.]){7,12}/g,
@@ -48,11 +48,12 @@ const maskString = (
   } = options
 
   const unmaskedPartFromStart = text.slice(0, visibleCharsFromStart)
-  const unmaskedPartFromEnd = text.slice(-visibleCharsFromEnd)
-  const partShouldBeMasked = text.slice(
-    visibleCharsFromStart,
-    -visibleCharsFromEnd
-  )
+  const unmaskedPartFromEnd =
+    visibleCharsFromEnd > 0 ? text.slice(-visibleCharsFromEnd) : ''
+  const partShouldBeMasked =
+    visibleCharsFromEnd > 0
+      ? text.slice(visibleCharsFromStart, -visibleCharsFromEnd)
+      : text.slice(visibleCharsFromStart)
   const maskedCharsCount =
     partShouldBeMasked.length > maxCharsToMask
       ? maxCharsToMask


### PR DESCRIPTION
There might be cases where we have international letters in email-address. This feat allows scandic letters. This also fixes a bug where the matched string is completely removed in case `visibleCharsFromEnd` is set to 0. 